### PR TITLE
Fix typo in module declaration

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/mdigger/mdfm
+module github.com/mdigger/mdfmt
 
 go 1.13
 


### PR DESCRIPTION
Module was incorrectly declared as "mdfm" instead of "mdfmt" which
messed up "go get" commands and resulted in an incorrectly named binary.